### PR TITLE
Untitled

### DIFF
--- a/nbt.h
+++ b/nbt.h
@@ -19,6 +19,7 @@ extern "C" {
 #include <stddef.h> /* for size_t */
 #include <stdint.h>
 #include <stdio.h>  /* for FILE* */
+#include <errno.h>
 
 #include "buffer.h" /* for struct buffer */
 #include "list.h"   /* For struct list_entry etc. */

--- a/nbt_treeops.c
+++ b/nbt_treeops.c
@@ -332,10 +332,10 @@ static bool names_are_equal(const nbt_node* node, void* vname)
     assert(node);
 
     if(name == NULL && node->name == NULL)
-      return true;
+        return true;
 
     if(!name || !node->name)
-      return false;
+        return false;
 
     return strcmp(node->name, name) == 0;
 }


### PR DESCRIPTION
Simple cleanup for names_are_equal in treeops.  Fixes a crash in craftd usage.
- Remove undefined behavior
- Make conditionals easier to understand
