### PR TITLE
CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,25 @@
+project(cnbt)
+
+cmake_minimum_required(VERSION 2.6)
+
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Debug)
+endif()
+
+IF (CMAKE_COMPILER_IS_GNUCXX)
+  set(CMAKE_C_FLAGS "-g -Wall -W -pedantic -std=c99")
+  set(CMAKE_C_FLAGS_DEBUG "-DDEBUG -g")
+  set(CMAKE_C_FLAGS_PROFILE "-DDEBUG -g -pg")
+  set(CMAKE_C_FLAGS_RELEASE "-march=native -O2 -s -DNDEBUG -fno-strict-aliasing")
+ENDIF()
+
+# Output paths
+set(EXECUTABLE_OUTPUT_PATH bin)
+
+ADD_LIBRARY(nbt
+  buffer.c
+  nbt_loading.c
+  nbt_parsing.c
+  nbt_treeops.c
+  nbt_util.c
+)


### PR DESCRIPTION
Added a CMake file. Both magical to use on its own, but also allows for easy-peasy inclusion of cNBT in other projects. I didn't include the test programs, as I only need the library itself; let me know if you like that expanded. I added "-fno-strict-aliasing" to the release build because you seem to be doing some type punning.
