### PR TITLE
PATCH: Added support for TAG_INT_ARRAY (tag 11)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@
 *.a
 *.plist
 tags
+check
+nbtreader
+regioninfo
+testdata/dump.bin
+testdata/dump2.bin

--- a/nbt.h
+++ b/nbt.h
@@ -30,17 +30,18 @@ typedef enum {
 } nbt_status;
 
 typedef enum {
-    TAG_INVALID    = 0, /* tag_end, but we don't use it in the in-memory representation. */
-    TAG_BYTE       = 1, /* char, 8 bits, signed */
-    TAG_SHORT      = 2, /* short, 16 bits, signed */
-    TAG_INT        = 3, /* long, 32 bits, signed */
-    TAG_LONG       = 4, /* long long, 64 bits, signed */
-    TAG_FLOAT      = 5, /* float, 32 bits, signed */
-    TAG_DOUBLE     = 6, /* double, 64 bits, signed */
-    TAG_BYTE_ARRAY = 7, /* char *, 8 bits, unsigned, TAG_INT length */
-    TAG_STRING     = 8, /* char *, 8 bits, signed, TAG_SHORT length */
-    TAG_LIST       = 9, /* X *, X bits, TAG_INT length, no names inside */
-    TAG_COMPOUND   = 10 /* nbt_tag * */
+    TAG_INVALID    = 0,  /* tag_end, but we don't use it in the in-memory representation. */
+    TAG_BYTE       = 1,  /* char, 8 bits, signed */
+    TAG_SHORT      = 2,  /* short, 16 bits, signed */
+    TAG_INT        = 3,  /* long, 32 bits, signed */
+    TAG_LONG       = 4,  /* long long, 64 bits, signed */
+    TAG_FLOAT      = 5,  /* float, 32 bits, signed */
+    TAG_DOUBLE     = 6,  /* double, 64 bits, signed */
+    TAG_BYTE_ARRAY = 7,  /* char *, 8 bits, unsigned, TAG_INT length */
+    TAG_STRING     = 8,  /* char *, 8 bits, signed, TAG_SHORT length */
+    TAG_LIST       = 9,  /* X *, X bits, TAG_INT length, no names inside */
+    TAG_COMPOUND   = 10, /* nbt_tag * */
+    TAG_INT_ARRAY  = 11
 
 } nbt_type;
 
@@ -79,6 +80,11 @@ typedef struct nbt_node {
             unsigned char* data;
             int32_t length;
         } tag_byte_array;
+
+        struct nbt_int_array {
+            unsigned int32_t* data;
+            int32_t length;
+        } tag_int_array;
 
         char* tag_string; /* TODO: technically, this should be a UTF-8 string */
 

--- a/nbt_treeops.c
+++ b/nbt_treeops.c
@@ -64,6 +64,9 @@ void nbt_free(nbt_node* tree)
     else if(tree->type == TAG_BYTE_ARRAY)
         free(tree->payload.tag_byte_array.data);
 
+    else if(tree->type == TAG_INT_ARRAY)
+        free(tree->payload.tag_int_array.data);
+
     else if(tree->type == TAG_STRING)
         free(tree->payload.tag_string);
 
@@ -151,6 +154,19 @@ nbt_node* nbt_clone(nbt_node* tree)
 
         ret->payload.tag_byte_array.data   = newbuf;
         ret->payload.tag_byte_array.length = tree->payload.tag_byte_array.length;
+    }
+
+    else if(tree->type == TAG_INT_ARRAY)
+    {
+        unsigned char* newbuf;
+        CHECKED_MALLOC(newbuf, tree->payload.tag_int_array.length * sizeof(int32_t), goto clone_error);
+
+        memcpy(newbuf,
+               tree->payload.tag_int_array.data,
+               tree->payload.tag_int_array.length);
+
+        ret->payload.tag_int_array.data   = newbuf;
+        ret->payload.tag_int_array.length = tree->payload.tag_int_array.length;
     }
 
     else if(tree->type == TAG_LIST)
@@ -278,6 +294,19 @@ nbt_node* nbt_filter(const nbt_node* tree, nbt_predicate_t filter, void* aux)
                tree->payload.tag_byte_array.length);
 
         ret->payload.tag_byte_array.length = tree->payload.tag_byte_array.length;
+    }
+
+    else if(tree->type == TAG_INT_ARRAY)
+    {
+        CHECKED_MALLOC(ret->payload.tag_int_array.data,
+                       tree->payload.tag_int_array.length * sizeof(int32_t),
+                       goto filter_error);
+
+        memcpy(ret->payload.tag_int_array.data,
+               tree->payload.tag_int_array.data,
+               tree->payload.tag_int_array.length);
+
+        ret->payload.tag_int_array.length = tree->payload.tag_int_array.length;
     }
 
     /* Okay, we want to keep this node, but keep traversing the tree! */

--- a/nbt_util.c
+++ b/nbt_util.c
@@ -27,6 +27,7 @@ const char* nbt_type_to_string(nbt_type t)
         DEF_CASE(TAG_STRING);
         DEF_CASE(TAG_LIST);
         DEF_CASE(TAG_COMPOUND);
+        DEF_CASE(TAG_INT_ARRAY);
     default:
         return "TAG_UNKNOWN";
     }
@@ -105,6 +106,11 @@ bool nbt_eq(const nbt_node* restrict a, const nbt_node* restrict b)
         return memcmp(a->payload.tag_byte_array.data,
                       b->payload.tag_byte_array.data,
                       a->payload.tag_byte_array.length) == 0;
+    case TAG_INT_ARRAY:
+        if(a->payload.tag_int_array.length != b->payload.tag_int_array.length) return false;
+        return memcmp(a->payload.tag_int_array.data,
+                      b->payload.tag_int_array.data,
+                      a->payload.tag_int_array.length) == 0;
     case TAG_STRING:
         return strcmp(a->payload.tag_string, b->payload.tag_string) == 0;
     case TAG_LIST:


### PR DESCRIPTION
TAG_INT_ARRAY is an addition of the Anvil format
and is very much like TAG_BYTE_ARRAY, except
with a payload of 4-byte integers.
