### PR TITLE
Renamed __strdup to _nbt_strdup(); was having problems with clang version 3.5.0 on ubuntu

### DIFF
--- a/nbt_treeops.c
+++ b/nbt_treeops.c
@@ -15,7 +15,7 @@
 #include <string.h>
 
 /* strdup isn't standard. GNU extension. */
-static inline char* __strdup(const char* s)
+static inline char* _nbt_strdup(const char* s)
 {
     char* r = malloc(strlen(s) + 1);
     if(r == NULL) return NULL;
@@ -121,7 +121,7 @@ clone_error:
 /* same as strdup, but handles NULL gracefully */
 static inline char* safe_strdup(const char* s)
 {
-    return s ? __strdup(s) : NULL;
+    return s ? _nbt_strdup(s) : NULL;
 }
 
 nbt_node* nbt_clone(nbt_node* tree)
@@ -139,7 +139,7 @@ nbt_node* nbt_clone(nbt_node* tree)
 
     if(tree->type == TAG_STRING)
     {
-        ret->payload.tag_string = __strdup(tree->payload.tag_string);
+        ret->payload.tag_string = _nbt_strdup(tree->payload.tag_string);
         if(ret->payload.tag_string == NULL) goto clone_error;
     }
 
@@ -279,7 +279,7 @@ nbt_node* nbt_filter(const nbt_node* tree, nbt_predicate_t filter, void* aux)
 
     if(tree->type == TAG_STRING)
     {
-        ret->payload.tag_string = __strdup(tree->payload.tag_string);
+        ret->payload.tag_string = _nbt_strdup(tree->payload.tag_string);
         if(ret->payload.tag_string == NULL) goto filter_error;
     }
 


### PR DESCRIPTION
See [issue 21](https://github.com/FliPPeh/cNBT/issues/21):

> It seems that some version of ubuntu/clang has an issue building cNBT, because of a __strdup() naming conflict; specifically, it is defined as a macro that expands to some crazy stuff in the GNU headers or something like this (macro defined at /usr/include/x86_64-linux-gnu/bits/string2.h:1280:4). Recommend renaming __strdup() to something else.

More info if you read the [issue](https://github.com/FliPPeh/cNBT/issues/21).

