### PR TITLE
parse_named_tag: Handle read_string error

### DIFF
--- a/nbt_parsing.c
+++ b/nbt_parsing.c
@@ -156,6 +156,7 @@ static nbt_node* parse_named_tag(const char** memory, size_t* length)
   READ_GENERIC(&type, sizeof type, memscan, goto parse_error);
 
   name = read_string(memory, length);
+  if(name == NULL) goto parse_error;
 
   nbt_node* ret = parse_unnamed_tag((nbt_type)type, name, memory, length);
   if(ret == NULL) goto parse_error;


### PR DESCRIPTION
When read_string fails in parse_named_tag, handle the error. This avoids a memory leak.

```
$ gcc -fsanitize=leak -O2 -g nbt*.c buffer.c afl_check.c -lz -o afl_check
$ echo H4sIAAFPPWQCA+3cMQ0AMAwDwTlszLJjKTckKkXK3fAYPLlOKk1ERERERLYGAAAAAAAAAAAAAAAAAAAAAAAAAL5xewcA2BgAAAAAwDA3yQPu9ekG1ncAAA== | base64 -d | gunzip | ./afl_check

================================================================= ==1071335==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 24 byte(s) in 1 object(s) allocated from:
    #0 0x7f6df2213545 in __interceptor_malloc ../../../../src/libsanitizer/lsan/lsan_interceptors.cpp:75
    #1 0x563703627739 in read_list /home/jn/dev/misc/cNBT/nbt_parsing.c:294
    #2 0x563703627739 in parse_unnamed_tag /home/jn/dev/misc/cNBT/nbt_parsing.c:431
    #3 0x7ffd360b3d2f  ([stack]+0x90d2f)

Indirect leak of 32 byte(s) in 1 object(s) allocated from:
    #0 0x7f6df2213545 in __interceptor_malloc ../../../../src/libsanitizer/lsan/lsan_interceptors.cpp:75
    #1 0x56370362774f in read_list /home/jn/dev/misc/cNBT/nbt_parsing.c:298
    #2 0x56370362774f in parse_unnamed_tag /home/jn/dev/misc/cNBT/nbt_parsing.c:431
    #3 0x7ffd360b3d2f  ([stack]+0x90d2f)

SUMMARY: LeakSanitizer: 56 byte(s) leaked in 2 allocation(s).
```